### PR TITLE
custom exceptions not showing their error messages

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -24,22 +24,28 @@ __version__ = '0.3.5'
 
 
 class FastaIndexingError(Exception):
-    pass
+    def __init__(self, msg=None):
+        self.msg = msg
+        super(FastaIndexingError, self).__init__(self.msg)
 
 
 class FetchError(Exception):
-    pass
+    def __init__(self, msg=None):
+        self.msg = msg
+        super(FetchError, self).__init__(self.msg)
 
 
 class BedError(Exception):
     def __init__(self, msg=None):
-        msg = 'Malformed BED entry!\n' if not msg else msg
-        super(BedError, self).__init__(msg)
+        self.msg = 'Malformed BED entry!\n' if not msg else msg
+        super(BedError, self).__init__(self.msg)
+
 
 class RegionError(Exception):
     def __init__(self, msg=None):
-        msg = 'Malformed region! Format = rname:start-end.\n' if not msg else msg
-        super(RegionError, self).__init__(msg)
+        self.msg = 'Malformed region! Format = rname:start-end.\n' if not msg else msg
+        super(RegionError, self).__init__(self.msg)        
+
 
 class Sequence(object):
     """

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -24,24 +24,22 @@ __version__ = '0.3.5'
 
 
 class FastaIndexingError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+    pass
 
 
 class FetchError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+    pass
 
 
 class BedError(Exception):
     def __init__(self, msg=None):
-        self.msg = 'Malformed BED entry!\n' if not msg else msg
-
+        msg = 'Malformed BED entry!\n' if not msg else msg
+        super(BedError, self).__init__(msg)
 
 class RegionError(Exception):
     def __init__(self, msg=None):
-        self.msg = 'Malformed region! Format = rname:start-end.\n' if not msg else msg
-
+        msg = 'Malformed region! Format = rname:start-end.\n' if not msg else msg
+        super(RegionError, self).__init__(msg)
 
 class Sequence(object):
     """

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -48,7 +48,7 @@ def write_sequence(args):
             for line in fetch_sequence(args, fasta, name, start, end):
                 outfile.write(line)
         except FetchError as e:
-            raise FetchError(e.message.rstrip() + "Try setting --lazy.\n")
+            raise FetchError(e.msg.rstrip() + "Try setting --lazy.\n")
         if args.split_files:
             outfile.close()
     fasta.__exit__()

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -48,7 +48,7 @@ def write_sequence(args):
             for line in fetch_sequence(args, fasta, name, start, end):
                 outfile.write(line)
         except FetchError as e:
-            raise FetchError(e.msg.rstrip() + "Try setting --lazy.\n")
+            raise FetchError(e.message.rstrip() + "Try setting --lazy.\n")
         if args.split_files:
             outfile.close()
     fasta.__exit__()


### PR DESCRIPTION
Hey, love pyfaidx so far- really useful and nicely done. I had noticed that in some rare cases, I get a FastaIndexError without any error message, and upon further investigation, I can't get any of your custom errors to display the error message they were called with. I'm using Python 2.7.6 and the most recent version of pyfaidx from pip.

I think the `__init__` constructor for these exceptions is incomplete- you need to call the parent's `__init__` function. But it may not even be necessary for FastaIndexingError, etc- just do 
```python
class FastaIndexingError:
    pass
```
for instance, and it will handle the exception message for you when you call it:
```python
>>> raise FastaIndexingError("some error")
FastaIndexingError: some error
```
The pull request makes these changes and passes the test suite. 
Cheers,
Erik