### PR TITLE
Change build_index to only occur for old index

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -227,7 +227,7 @@ class Faidx(object):
 
         self.mutable = mutable
 
-        if os.path.exists(self.indexname) and getmtime(self.indexname) > getmtime(self.filename):
+        if os.path.exists(self.indexname) and getmtime(self.indexname) >= getmtime(self.filename):
             self.read_fai(split_char)
         else:
             try:


### PR DESCRIPTION
In current implementation a new index file will be created if the index file modification time is older than, or equal, to the fasta file. In some cases, e.g. if the files are downloaded as part of an external bundle, the modification times could be equal for all files. In such cases you often want to preserve the original index.

Fix this by only building index if the index is older than the fasta file. If they have equal mtime, it will be used instead.

The day-to-day reason behind wanting this change is that we're using the reference fasta file from the GATK bundle, and we don't trust to change it from the original bundle index used by GATK. As we don't always have control how the bundle is deployed, touching the index file for each deployment is also a hassle.