### PR TITLE
Remove errant print

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -519,7 +519,6 @@ class FastaRecord(object):
                     stop = len(self) + stop
                 if start < 0:
                     start = len(self) + start
-                print(stop)
                 return self._fa.get_seq(self.name, start + 1, stop)[::step]
 
             elif isinstance(n, int):


### PR DESCRIPTION
Was printing a coordinate to STDOUT on each subset from the Fasta() class.