### PR TITLE
Fix complement() to work on empty strings, better performance

### DIFF
--- a/tests/test_sequence_class.py
+++ b/tests/test_sequence_class.py
@@ -33,4 +33,9 @@ def test_comp_invalid():
     complement(comp_invalid)
 
 def test_comp_valid():
-    complement(comp_valid)
+    assert complement(comp_valid).startswith("AACTTCTAAAnCG")
+    assert complement(complement(comp_valid)) == comp_valid
+
+def test_comp_empty():
+    assert complement('') == ''
+


### PR DESCRIPTION
Modify pyfaidx.complement() to work on empty sequences (closes #81), add a test for this case, and use a more efficient implementation of this function.

On my machine, complementing a 55-character string goes from about 3.4us to 800ns with this change.