### PR TITLE
Issue #96 and Tox configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,15 @@
 [run]
+parallel = True
 omit =
-    */python?.?/*
     */lib-python/?.?/*.py
     */lib_pypy/_*.py
     */site-packages/ordereddict.py
     */site-packages/nose/*
     */site-packages/six/*
     */unittest2/*
+
+[paths]
+source =
+    pyfaidx
+    .tox/*/lib/python*/site-packages/pyfaidx
+    .tox/*/site-packages/pyfaidx

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ __pycache__
 *.pyc
 .project
 .pydevproject
-
+.idea
+*.egg-info
+.tox
+.coverage
+.coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .tox
 .coverage
 .coverage.*
+tests/data/chr22*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,11 @@ install:
   # We need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install -r dev-requirements.txt"
 
+  # Fix for problem building extensions for x64 under Python 3.3 and 3.4
+  # See: http://help.appveyor.com/discussions/problems/4278-cant-build-some-c-extensions-with-python-34-x64
+  # Used same solution as Matplotlib: https://github.com/matplotlib/matplotlib/blob/master/appveyor.yml
+  - cmd: copy ci\appveyor\vcvars64.bat "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64"
+
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,13 +17,13 @@ environment:
     - PYTHON: "C:\\Python35-x64"
 
 install:
-  # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install -r dev-requirements.txt"
-
   # Fix for problem building extensions for x64 under Python 3.3 and 3.4
   # See: http://help.appveyor.com/discussions/problems/4278-cant-build-some-c-extensions-with-python-34-x64
   # Used same solution as Matplotlib: https://github.com/matplotlib/matplotlib/blob/master/appveyor.yml
   - cmd: copy ci\appveyor\vcvars64.bat "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64"
+
+  # We need wheel installed to build wheels
+  - "%PYTHON%\\python.exe -m pip install -r dev-requirements.txt"
 
 build: off
 

--- a/ci/appveyor/vcvars64.bat
+++ b/ci/appveyor/vcvars64.bat
@@ -1,0 +1,1 @@
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ six
 nose
 biopython
 setuptools >= 0.7
+mock; python_version < '3.3'

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -312,7 +312,12 @@ class Faidx(object):
                 self.read_fai(split_char)
         except FastaIndexingError as e:
             os.remove(self.indexname)
+            self.file.close()
             raise FastaIndexingError(e)
+        except Exception:
+            # Handle potential exceptions other than 'FastaIndexingError'
+            self.file.close()
+            raise
         finally:
             self.lock.release()
 

--- a/tests/test_FastaRecord.py
+++ b/tests/test_FastaRecord.py
@@ -50,17 +50,17 @@ class TestFastaRecord(TestCase):
         """ Check for pathogenic FastaRecord.long_name behavior in mdshw5/pyfaidx#62 """
         deflines = []
         line_len = None
-        with open('data/genes.fasta') as fasta_file:
-            with open('data/issue_62.fa', 'w') as fasta_uniform_len:
+        with open('data/genes.fasta', 'rb') as fasta_file:
+            with open('data/issue_62.fa', 'wb') as fasta_uniform_len:
                 for line in fasta_file:
-                    if line[0] == '>':
-                        deflines.append(line[1:-1])
+                    if line.startswith(b'>'):
+                        deflines.append(line[1:-1].decode('ascii'))
                         fasta_uniform_len.write(line)
                     elif line_len is None:
                         line_len = len(line)
                         fasta_uniform_len.write(line)
                     elif line_len > len(line):
-                        fasta_uniform_len.write(line.rstrip() + 'N' * (line_len - len(line)) + '\n')
+                        fasta_uniform_len.write(line.rstrip() + b'N' * (line_len - len(line)) + b'\n')
                     else:
                         fasta_uniform_len.write(line)
         fasta = Fasta('data/issue_62.fa', as_raw=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,39 @@
+[tox]
+envlist = init, py26, py27, py33, py34, py35, pypy, pypy3, final
+
+[testenv]
+deps = nose
+       coverage
+       nose-cov
+commands = nosetests --with-cov --cov-report term-missing --cov {envsitepackagesdir}/pyfaidx -P tests
+           coverage combine
+           bash -c 'mv {toxinidir}/.coverage {toxworkdir}/.coverage.{envname}'
+whitelist_externals = bash
+
+[testenv:py26]
+deps = nose
+       mock
+       coverage
+       nose-cov
+
+[testenv:py27]
+deps = nose
+       mock
+       coverage
+       nose-cov
+
+[testenv:pypy]
+deps = nose
+       mock
+       coverage
+       nose-cov
+
+[testenv:init]
+commands = coverage erase
+           bash -c 'rm -rf {toxworkdir}/.coverage.*'
+
+[testenv:final]
+basepython = python2.7
+commands = coverage combine {toxworkdir}
+           coverage report -m
+

--- a/tox.ini
+++ b/tox.ini
@@ -3,34 +3,22 @@ envlist = init, py26, py27, py33, py34, py35, pypy, pypy3, final
 
 [testenv]
 deps = nose
+       mock; python_version < '3.3'
        coverage
        nose-cov
+       biopython
+       pysam; python_version > '2.6' and platform_python_implementation != 'PyPy'
+       pyvcf
 commands = nosetests --with-cov --cov-report term-missing --cov {envsitepackagesdir}/pyfaidx -P tests
            coverage combine
            bash -c 'mv {toxinidir}/.coverage {toxworkdir}/.coverage.{envname}'
 whitelist_externals = bash
 
-[testenv:py26]
-deps = nose
-       mock
-       coverage
-       nose-cov
-
-[testenv:py27]
-deps = nose
-       mock
-       coverage
-       nose-cov
-
-[testenv:pypy]
-deps = nose
-       mock
-       coverage
-       nose-cov
-
 [testenv:init]
+basepython = python2.7
 commands = coverage erase
            bash -c 'rm -rf {toxworkdir}/.coverage.*'
+           python tests/data/download_gene_fasta.py
 
 [testenv:final]
 basepython = python2.7


### PR DESCRIPTION
The tests for #96 add a new dependency on the 'mock' project for py26, py26, and pypy. You can decide whether it is worth adding that dependency to implement a corner case.

The provided Tox configuration will merge coverage information across multiple test environments, and this required some changes to the coverage configuration in order to merge coverage statistics across multiple instances of the installed 'pyfaidx' package, and it limits coverage reporting to just the 'pyfaidx' package. I'm not sure if that adversely affects how you currently use the coverage report, but if it does the coverage logic can be removed.