### PR TITLE
Proof of concept support for BGZF compressed FASTA files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -474,6 +474,19 @@ A lower-level Faidx class is also available:
    where "filename.fa" is the original FASTA file.
 -  Start and end coordinates are 1-based.
 
+Support for compressed FASTA
+----------------------------
+
+``pyfaidx`` can create and read ``.fai`` indices for FASTA files that have
+been compressed using the `bgzip <http://www.htslib.org/doc/tabix.html>`
+tool from `samtools <http://www.htslib.org/>`. ``bgzip`` writes compressed
+data in a ``BGZF`` format. ``BGZF`` is ``gzip`` compatible, consisting of
+multiple concatenated ``gzip`` blocks, each with an additional ``gzip``
+header making it possible to build an index for rapid random access. I.e.,
+files compressed with ``bgzip`` are valid ``gzip`` and so can be read by
+``gunzip``.  See `this page
+<http://pydoc.net/Python/biopython/1.66/Bio.bgzf/>` for more details on
+``bgzip``.
 
 Changelog
 ---------

--- a/README.rst
+++ b/README.rst
@@ -478,14 +478,14 @@ Support for compressed FASTA
 ----------------------------
 
 ``pyfaidx`` can create and read ``.fai`` indices for FASTA files that have
-been compressed using the `bgzip <http://www.htslib.org/doc/tabix.html>`
-tool from `samtools <http://www.htslib.org/>`. ``bgzip`` writes compressed
+been compressed using the `bgzip <http://www.htslib.org/doc/tabix.html>`_
+tool from `samtools <http://www.htslib.org/>`_. ``bgzip`` writes compressed
 data in a ``BGZF`` format. ``BGZF`` is ``gzip`` compatible, consisting of
 multiple concatenated ``gzip`` blocks, each with an additional ``gzip``
 header making it possible to build an index for rapid random access. I.e.,
 files compressed with ``bgzip`` are valid ``gzip`` and so can be read by
-``gunzip``.  See `this page
-<http://pydoc.net/Python/biopython/1.66/Bio.bgzf/>` for more details on
+``gunzip``.  See `this description
+<http://pydoc.net/Python/biopython/1.66/Bio.bgzf/>`_ for more details on
 ``bgzip``.
 
 Changelog

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -399,9 +399,6 @@ class Faidx(object):
                     bad_lines = []  # lines > || < than blen
                     thisoffset = offset
 
-                    def getOffset():
-                        return fastafile.tell() if self._bgzf else offset
-
                     for i, line in enumerate(fastafile):
                         line_blen = len(line)
                         line_clen = len(line.rstrip('\n\r'))
@@ -425,7 +422,7 @@ class Faidx(object):
                             except IndexError:
                                 raise FastaIndexingError("Bad sequence name %s at line %s." % (line.rstrip('\n\r'), str(i)))
                             offset += line_blen
-                            thisoffset = getOffset()
+                            thisoffset = fastafile.tell() if self._bgzf else offset
                         else:  # check line and advance offset
                             if not blen:
                                 blen = line_blen

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -37,6 +37,12 @@ class BedError(Exception):
     """Indicates a malformed BED entry."""
 
 
+class RegionError(Exception):
+    # This exception class is currently unused, but has been retained for
+    # backwards compatibility.
+    """A region error occurred."""
+
+
 class UnsupportedCompressionFormat(Exception):
     """
     Raised when a FASTA file is given with a recognized but unsupported

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -399,10 +399,7 @@ class Faidx(object):
                     thisoffset = offset
 
                     def getOffset():
-                        if self._bgzf:
-                            return fastafile.tell()
-                        else:
-                            return offset
+                        return fastafile.tell() if self._bgzf else offset
 
                     for i, line in enumerate(fastafile):
                         line_blen = len(line)

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -52,7 +52,7 @@ def write_sequence(args):
                 for line in fetch_sequence(args, fasta, name, start, end):
                     outfile.write(line)
         except FetchError as e:
-            raise FetchError(e.msg.rstrip() + "Try setting --lazy.\n")
+            raise FetchError(str(e) + " Try setting --lazy.\n")
         if args.split_files:
             outfile.close()
     fasta.__exit__()


### PR DESCRIPTION
This shouldn't be merged yet, I'm just sending the pr to get feedback / comments and to show something that seems to work. See #77.

To use, compress a FASTA file wtih bgzip (see http://www.htslib.org/doc/tabix.html). Rename the file to have a `.bgz` suffix. You can then create an `.fai` index for that file using the `Faidx` class and read it using the `Fasta` class.

I have a small test index creation file:
```python
#!/usr/bin/env python
from pyfaidx import Faidx
Faidx('data.fasta.bgz')
```

and a text lookup file:
```python
#!/usr/bin/env python
from pyfaidx import Fasta
f = Fasta('data.fasta.bgz')

assert str(f['read-18']) == 'GATGCTGCCACGCTAGGAACGCGCGCTGATAGTTTTCATAATAGAATGTACAAGTGTGTGTTTGCTTTCCTACAAACAGCTCATAAGCCGGAGTCCGCAA'
assert str(f['read-9994']) == 'CAGGTTTTGTCCGCTGTCGCCATCATCGTCTATTGTAGTTCTGCAGAGGCCCCTAAACACAAAATCCGGGCGGCATAATAGAAGCGCATTCTGCTTTGCC'
```

These (and the `data.fasta` file referred to) can be found in the attached zip file.

Note that: this package could support the writing of the compressed FASTA (via the Bio.bgzf module) so `bgzip` would not need to be installed. Also, to see that the changes are really doing something (i.e., using BGZF virtual offsets) you need to create an index for a FASTA file with more than 64K bytes. The file in the attached zip is sufficient. If you look in the `.fai` file, you'll see the offsets change dramatically (as expected) once 64K is reached.

I've not tried to write any tests (I didn't see any tests for `build_index`). Let's see if this approach makes sense to you and, if so, talk about how to proceed. The code change is pretty minimal. I'm happy to help, because it would be very useful to have this code working on compressed input files.

[bgzf.zip](https://github.com/mdshw5/pyfaidx/files/960103/bgzf.zip)
