### PR TITLE
Added basic support for auto reverse-complements

### DIFF
--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -61,6 +61,10 @@ def write_sequence(args):
 def fetch_sequence(args, fasta, name, start=None, end=None):
     try:
         line_len = fasta.faidx.index[name].lenc
+        if start is not None and end is not None and start > end:
+            end, start = start, end
+            args.complement = not args.complement
+            args.reverse = not args.reverse
         sequence = fasta[name][start:end]
     except KeyError:
         sys.stderr.write("warning: {name} not found in file\n".format(**locals()))

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -75,7 +75,6 @@ def fetch_sequence(args, fasta, name, start=None, end=None):
     if args.reverse:
         sequence = sequence.reverse
     if args.auto_strand:
-        
             sequence = sequence.complement
     if args.no_output:
         return
@@ -189,6 +188,11 @@ def main(ext_args=None):
     else:
         write_sequence(args)
 
+if args.auto_strand:
+    if args.complement:
+        sys.stderr.write("--auto-strand and --complement are both set. Are you sure this is what you want?\n")
+    if args.reverse:
+        sys.stderr.write("--auto-strand and --reverse are both set. Are you sure this is what you want?\n")
 
 def check_seq_length(value):
     if len(value) != 1:


### PR DESCRIPTION
Added basic support for reverse-complement a sequence automatically, if the start coordinate of a range is larger than the end coordinate.

It is useful, i.e. to directly extract subsequences based on BLAST hit coordinates without dealing with its strandness.