### PR TITLE
Pass build_index to Fasta constructor

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -960,7 +960,8 @@ class Fasta(object):
             read_long_names=read_long_names,
             duplicate_action=duplicate_action,
             sequence_always_upper=sequence_always_upper,
-            rebuild=rebuild)
+            rebuild=rebuild,
+            build_index=build_index)
         self.keys = self.faidx.index.keys
         if not self.mutable:
             self.records = dict(


### PR DESCRIPTION
The `Fasta` constructor should not ignore the `build_index` parameter, but pass it to the `Fasta` constructor.