### PR TITLE
Add support for reading from S3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,5 @@ six
 nose
 biopython
 setuptools >= 0.7
+smart_open >= 1.7.1
 mock; python_version < '3.3'

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -505,7 +505,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with smart_open(self.indexname, 'w', server_side_encryption="AES256") as indexfile:
+                with smart_open(self.indexname, 'w', ServerSideEncryption="AES256") as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -590,7 +590,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with smart_open(self.indexname, 'w', server_side_encryption="AES256") as outfile:
+            with smart_open(self.indexname, 'w', ServerSideEncryption="AES256") as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -19,6 +19,7 @@ import string
 import warnings
 from math import ceil
 from threading import Lock
+from smart_open import smart_open
 
 if sys.version_info > (3, ):
     buffer = memoryview
@@ -351,7 +352,7 @@ class Faidx(object):
                 "Compressed FASTA is only supported in BGZF format. Use "
                 "bgzip to compresss your FASTA.")
         else:
-            self._fasta_opener = open
+            self._fasta_opener = smart_open
             self._bgzf = False
 
         try:
@@ -453,7 +454,7 @@ class Faidx(object):
 
     def read_fai(self):
         try:
-            with open(self.indexname) as index:
+            with smart_open(self.indexname) as index:
                 prev_bend = 0
                 drop_keys = []
                 for line in index:
@@ -504,7 +505,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with open(self.indexname, 'w') as indexfile:
+                with smart_open(self.indexname, 'w') as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -589,7 +590,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with open(self.indexname, 'w') as outfile:
+            with smart_open(self.indexname, 'w') as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 
@@ -917,7 +918,7 @@ class FastaRecord(object):
 class MutableFastaRecord(FastaRecord):
     def __init__(self, name, fa):
         super(MutableFastaRecord, self).__init__(name, fa)
-        if self._fa.faidx._fasta_opener != open:
+        if self._fa.faidx._fasta_opener != smart_open:
             raise UnsupportedCompressionFormat(
                 "BGZF compressed FASTA is not supported for MutableFastaRecord. "
                 "Please decompress your FASTA file.")

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -505,7 +505,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with smart_open(self.indexname, 'w') as indexfile:
+                with smart_open(self.indexname, 'w', server_side_encryption="AES256") as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -590,7 +590,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with smart_open(self.indexname, 'w') as outfile:
+            with smart_open(self.indexname, 'w', server_side_encryption="AES256") as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -505,7 +505,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with smart_open(self.indexname, 'w', encoding='utf8') as indexfile:
+                with smart_open(self.indexname, 'w') as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -590,7 +590,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with smart_open(self.indexname, 'w', encoding='utf8') as outfile:
+            with smart_open(self.indexname, 'w') as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -28,6 +28,8 @@ dna_bases = re.compile(r'([ACTGNactgnYRWSKMDVHBXyrwskmdvhbx]+)')
 
 __version__ = '0.5.5'
 
+s3_config = {"ServerSideEncryption": "AES256",
+             "GrantFullControl": 'emailaddress=aws-master-admins@humanlongevity.com;emailaddress=aws-sdrad-admins@humanlongevity.com'}
 
 class KeyFunctionError(ValueError):
     """Raised if the key_function argument is invalid."""
@@ -330,6 +332,8 @@ class Faidx(object):
           Default: False (i.e. return a Sequence() object).
         """
         self.filename = filename
+        self.s3_config = {"ServerSideEncryption": "AES256",
+                          "GrantFullControl": 'emailaddress=aws-master-admins@humanlongevity.com;emailaddress=aws-sdrad-admins@humanlongevity.com'}
 
         if filename.lower().endswith('.bgz') or filename.lower().endswith(
                 '.gz'):
@@ -505,7 +509,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with smart_open(self.indexname, 'w', ServerSideEncryption="AES256") as indexfile:
+                with smart_open(self.indexname, 'w', config=s3_config) as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -590,7 +594,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with smart_open(self.indexname, 'w', ServerSideEncryption="AES256") as outfile:
+            with smart_open(self.indexname, 'w', confg=s3_config) as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -454,7 +454,7 @@ class Faidx(object):
 
     def read_fai(self):
         try:
-            with smart_open(self.indexname) as index:
+            with smart_open(self.indexname, encoding='utf8') as index:
                 prev_bend = 0
                 drop_keys = []
                 for line in index:
@@ -505,7 +505,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with smart_open(self.indexname, 'w') as indexfile:
+                with smart_open(self.indexname, 'w', encoding='utf8') as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -590,7 +590,7 @@ class Faidx(object):
 
     def write_fai(self):
         with self.lock:
-            with smart_open(self.indexname, 'w') as outfile:
+            with smart_open(self.indexname, 'w', encoding='utf8') as outfile:
                 for line in self._index_as_string:
                     outfile.write(line)
 

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -38,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = smart_open(filename, 'w', encoding='utf8')
+            outfile = smart_open(filename, 'w')
         elif args.out:
             outfile = args.out
         else:

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -38,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = smart_open(filename, 'w')
+            outfile = smart_open(filename, 'w', server_side_encryption="AES256")
         elif args.out:
             outfile = args.out
         else:

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -38,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = smart_open(filename, 'w')
+            outfile = smart_open(filename, 'w', encoding='utf8')
         elif args.out:
             outfile = args.out
         else:

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -38,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = smart_open(filename, 'w', server_side_encryption="AES256")
+            outfile = smart_open(filename, 'w', ServerSideEncryption="AES256")
         elif args.out:
             outfile = args.out
         else:

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 import os.path
 import re
-from pyfaidx import Fasta, wrap_sequence, FetchError, ucsc_split, bed_split
+from pyfaidx import Fasta, wrap_sequence, FetchError, ucsc_split, bed_split, s3_config
 from collections import defaultdict
 from smart_open import smart_open
 
@@ -38,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = smart_open(filename, 'w', ServerSideEncryption="AES256")
+            outfile = smart_open(filename, 'w', config=s3_config)
         elif args.out:
             outfile = args.out
         else:

--- a/pyfaidx/cli.py
+++ b/pyfaidx/cli.py
@@ -5,6 +5,7 @@ import os.path
 import re
 from pyfaidx import Fasta, wrap_sequence, FetchError, ucsc_split, bed_split
 from collections import defaultdict
+from smart_open import smart_open
 
 keepcharacters = (' ', '.', '_')
 
@@ -37,7 +38,7 @@ def write_sequence(args):
         if args.split_files:  # open output file based on sequence name
             filename = '.'.join(str(e) for e in (name, start, end, ext) if e)
             filename = ''.join(c for c in filename if c.isalnum() or c in keepcharacters)
-            outfile = open(filename, 'w')
+            outfile = smart_open(filename, 'w')
         elif args.out:
             outfile = args.out
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from io import open
 import sys
 
-install_requires = ['six', 'setuptools >= 0.7']
+install_requires = ['six', 'setuptools >= 0.7', 'smart_open >= 1.7.1']
 if sys.version_info[0] == 2 and sys.version_info[1] == 6:
     install_requires.extend(['ordereddict', 'argparse'])
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 install_requires = ['six', 'setuptools >= 0.7', 'smart_open >= 1.7.1']
 if sys.version_info[0] == 2 and sys.version_info[1] == 6:
-    install_requires.extend(['ordereddict', 'argparse'])
+    install_requires.extend(['ordereddict', 'argparse', 'importlib'])
 
 
 def get_version(string):

--- a/tests/test_feature_indexing.py
+++ b/tests/test_feature_indexing.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile, mkdtemp
 import time
 import platform
 import shutil
+from smart_open import smart_open
 
 try:
     from unittest import mock
@@ -77,7 +78,7 @@ class TestIndexing(TestCase):
                         "gi|530364725|ref|XR_241080.1|	4884	65918	70	72\n"
                         "gi|530364724|ref|XR_241079.1|	2819	71079	70	72\n")
         index_file = Faidx('data/issue_141.fasta').indexname
-        result_index = open(index_file).read()
+        result_index = smart_open(index_file, encoding='utf8').read()
         os.remove('data/issue_141.fasta.fai')
         print(result_index)
         assert result_index == expect_index
@@ -241,7 +242,7 @@ class TestIndexing(TestCase):
         """
         expect_index = ("MT	119	4	70	71\nGL000207.1	60	187	60	61\n")
         index_file = Faidx('data/issue_83.fasta').indexname
-        result_index = open(index_file).read()
+        result_index = smart_open(index_file, encoding='utf8').read()
         os.remove('data/issue_83.fasta.fai')
         assert result_index == expect_index
 


### PR DESCRIPTION
- migrate standard python `open` commands to `smart_open` commands from library: https://github.com/RaRe-Technologies/smart_open in order to support fastas and indexes located on s3 or hdfs