### PR TITLE
Fasta more dict-like behaviour

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -998,6 +998,8 @@ class Fasta(object):
             rebuild=rebuild,
             build_index=build_index)
         self.keys = self.faidx.index.keys
+        self.values = self.faidx.index.values
+        self.items = self.faidx.index.items
         if not self.mutable:
             self.records = dict(
                 [(rname, FastaRecord(rname, self)) for rname in self.keys()])

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -997,9 +997,6 @@ class Fasta(object):
             sequence_always_upper=sequence_always_upper,
             rebuild=rebuild,
             build_index=build_index)
-        self.keys = self.faidx.index.keys
-        self.values = self.faidx.index.values
-        self.items = self.faidx.index.items
         if not self.mutable:
             self.records = dict(
                 [(rname, FastaRecord(rname, self)) for rname in self.keys()])
@@ -1061,6 +1058,15 @@ class Fasta(object):
         # Sequence coordinate validation wont work since
         # len(Sequence.seq) != end - start
         return Sequence(name=name, seq=seq, start=None, end=None)
+
+    def keys(self):
+        return self.records.keys()
+
+    def values(self):
+        return self.records.values()
+
+    def items(self):
+        return self.records.items()
 
     def close(self):
         self.__exit__()

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -1061,7 +1061,6 @@ class Fasta(object):
         return Sequence(name=name, seq=seq, start=None, end=None)
 
     def keys(self):
-        print('using our keys')
         return self.records.keys()
 
     def values(self):

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -997,13 +997,9 @@ class Fasta(object):
             sequence_always_upper=sequence_always_upper,
             rebuild=rebuild,
             build_index=build_index)
-        if not self.mutable:
-            self.records = {rname: FastaRecord(rname, self)
-                            for rname in self.faidx.index.keys()}
-        elif self.mutable:
-            self.records = {rname: MutableFastaRecord(rname, self)
-                            for rname in self.faidx.index.keys()}
-
+        
+        _record_constructor = MutableFastaRecord if self.mutable else FastaRecord
+        self.records = OrderedDict([(rname, _record_constructor(rname, self)) for rname in self.faidx.index.keys()])
 
     def __contains__(self, rname):
         """Return True if genome contains record."""

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -25,7 +25,7 @@ if sys.version_info > (3, ):
 
 dna_bases = re.compile(r'([ACTGNactgnYRWSKMDVHBXyrwskmdvhbx]+)')
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 
 
 class KeyFunctionError(ValueError):

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -998,11 +998,12 @@ class Fasta(object):
             rebuild=rebuild,
             build_index=build_index)
         if not self.mutable:
-            self.records = dict(
-                [(rname, FastaRecord(rname, self)) for rname in self.keys()])
+            self.records = {rname: FastaRecord(rname, self)
+                            for rname in self.faidx.index.keys()}
         elif self.mutable:
-            self.records = dict([(rname, MutableFastaRecord(rname, self))
-                                 for rname in self.keys()])
+            self.records = {rname: MutableFastaRecord(rname, self)
+                            for rname in self.faidx.index.keys()}
+
 
     def __contains__(self, rname):
         """Return True if genome contains record."""
@@ -1060,6 +1061,7 @@ class Fasta(object):
         return Sequence(name=name, seq=seq, start=None, end=None)
 
     def keys(self):
+        print('using our keys')
         return self.records.keys()
 
     def values(self):

--- a/tests/test_FastaRecord.py
+++ b/tests/test_FastaRecord.py
@@ -46,6 +46,7 @@ class TestFastaRecord(TestCase):
         long_names = []
         for record in fasta:
             long_names.append(record.long_name)
+        print(tuple(zip(deflines, long_names)))
         assert deflines == long_names
 
     def test_issue_62(self):


### PR DESCRIPTION
It is a very minor thing, but now `pyfaidx.Fasta` behaves slightly more dictionary-like with `.items` and `.values`.
