### PR TITLE
Minor improvement in integer indexing Fasta class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 before_install: 
     - 
 before_script:
-    - env pip3 install --user biopython
+    - env pip3 install biopython
     - env python3 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 before_install: 
     - 
 before_script:
-    - sudo apt-get -y install python3-biopython
+    - env pip3 install --user biopython
     - env python3 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ install:
     - make
     - export PATH=$PATH:$PWD
     - cd ..
+before_install: 
+    - 
 before_script:
-    - env pip install biopython
+    - sudo apt-get -y install python-biopython
     - env python tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - cd ..
 before_install: 
     - sudo apt-get install -y python3.6
-    - env pip3.6 install biopython
+    - env python3.6 -m pip install biopython
     - env python3.6 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 sudo: required
-dist: xenial
+dist: bionic
 python:
     - 'nightly'
+    - '3.8'
     - '3.7'
     - '3.6'
     - '3.5'
@@ -10,7 +11,8 @@ python:
     - 'pypy'
     - 'pypy3'
 install:
-    - pip install cython pysam biopython requests coverage pyfasta pyvcf numpy
+    - pip install cython pysam requests coverage pyfasta pyvcf numpy
+    - pip install biopython || true
     - python setup.py install
     - if [ ! -f samtools-1.2 ]; then curl -sL https://github.com/samtools/samtools/releases/download/1.2/samtools-1.2.tar.bz2 | tar -xjv; fi
     - cd samtools-1.2
@@ -23,7 +25,8 @@ install:
     - export PATH=$PATH:$PWD
     - cd ..
 before_script:
-    - python tests/data/download_gene_fasta.py
+    - env pip install biopython
+    - env python tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:
   provider: pypi
@@ -32,7 +35,7 @@ deploy:
     secure: MbSaeuitkVTZqxa0PJ3RcR1aMf+B/sMbcx2sWOo9xfLlRFDFpYWJZ0EfXWEhrVu2YWXpBsasgunTDWSi0jNcZMH92MzOC+UTVYr45LO5sy6hm4iSiAgm/DPgYWdjP0SFKr7eL/HWPS+gHvgkXL1upleX21O358bxaezoasuKFvs=
   on:
     all_branches: true
-    python: 3.7
+    python: 3.8
     tags: true
     repo: mdshw5/pyfaidx
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 before_install: 
     - 
 before_script:
-    - sudo apt-get -y install python-biopython
-    - env python tests/data/download_gene_fasta.py
+    - sudo apt-get -y install python3-biopython
+    - env python3 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 before_install: 
     - sudo apt-get install -y python3.6
 before_script:
-    - env pip3 install biopython
-    - env python3 tests/data/download_gene_fasta.py
+    - env pip3.6 install biopython
+    - env python3.6 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - export PATH=$PATH:$PWD
     - cd ..
 before_install: 
-    - sudo apt-get install -y python3.6
+    - sudo apt-get install -y python3.6 python3-pip
     - env python3.6 -m pip install biopython
     - env python3.6 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - export PATH=$PATH:$PWD
     - cd ..
 before_install: 
-    - 
+    - sudo apt-get install -y python3.6
 before_script:
     - env pip3 install biopython
     - env python3 tests/data/download_gene_fasta.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ install:
     - cd ..
 before_install: 
     - sudo apt-get install -y python3.6
-before_script:
     - env pip3.6 install biopython
     - env python3.6 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -4,21 +4,25 @@ Fasta file -> Faidx -> Fasta -> FastaRecord -> Sequence
 """
 
 from __future__ import division
+
 import os
+import re
+import string
 import sys
+import warnings
+from collections import namedtuple
+from itertools import islice
+from math import ceil
 from os.path import getmtime
-from six import PY2, PY3, string_types, integer_types
+from threading import Lock
+
+from six import PY2, PY3, integer_types, string_types
 from six.moves import zip_longest
+
 try:
     from collections import OrderedDict
 except ImportError:  #python 2.6
     from ordereddict import OrderedDict
-from collections import namedtuple
-import re
-import string
-import warnings
-from math import ceil
-from threading import Lock
 
 if sys.version_info > (3, ):
     buffer = memoryview
@@ -1015,7 +1019,7 @@ class Fasta(object):
     def __getitem__(self, rname):
         """Return a chromosome by its name, or its numerical index."""
         if isinstance(rname, integer_types):
-            rname = tuple(self.keys())[rname]
+            rname = next(islice(self.records.keys(), rname, None))
         try:
             return self.records[rname]
         except KeyError:
@@ -1025,9 +1029,8 @@ class Fasta(object):
         return 'Fasta("%s")' % (self.filename)
 
     def __iter__(self):
-        for rname in self.keys():
-            yield self[rname]
-            
+        return iter(self.records.values())
+
     def __len__(self):
         """Return the cumulative length of all FastaRecords in self.records."""
         return sum(len(record) for record in self)


### PR DESCRIPTION
With the change in `__getitem__`, not the full length of key() is iterated, but just as many elements as necessary.
When at it, `__iter__` calls here avoid the type check by not calling `__getitem__`.
Also, the imports were sorted.

Signed-off-by: Joris Cadow <joriscadow@gmail.com>