### PR TITLE
Implement fsspec in place of open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
     - 'pypy'
     - 'pypy3'
 install:
-    - pip install cython pysam requests coverage pyfasta pyvcf numpy
+    - pip install cython pysam requests coverage pyfasta pyvcf numpy fsspec
     - pip install biopython || true
     - python setup.py install
     - if [ ! -f samtools-1.2 ]; then curl -sL https://github.com/samtools/samtools/releases/download/1.2/samtools-1.2.tar.bz2 | tar -xjv; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
     - export PATH=$PATH:$PWD
     - cd ..
 before_install: 
-    - sudo apt-get install -y python3.6 python3-pip python3-requests
-    - env python3.6 -m pip install biopython
+    - sudo apt-get install -y python3.6 python3-pip
+    - env python3.6 -m pip install biopython requests
     - env python3.6 tests/data/download_gene_fasta.py
 script: nosetests --with-coverage --cover-package=pyfaidx
 deploy:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,3 @@ six
 nose
 biopython
 setuptools >= 0.7
-mock; python_version < '3.3'

--- a/tests/test_feature_indexing.py
+++ b/tests/test_feature_indexing.py
@@ -79,7 +79,7 @@ class TestIndexing(TestCase):
         index_file = Faidx('data/issue_141.fasta').indexname
         result_index = open(index_file).read()
         os.remove('data/issue_141.fasta.fai')
-        print(result_index)
+        #print(result_index)
         assert result_index == expect_index
 
     def test_build_issue_111(self):


### PR DESCRIPTION
Hi, as discussed in #165 here is a PR leveraging fsspec.

The code changes are straightforward. Though I am having trouble getting tests to pass. Any pointers would be appreciated.

The other thing that might be worth considering is the use of `Bio.bgzf`. I think that reading of `gz` files can be done directly, as `bgz` should be fully compatible. It might be a case of using `fsspec.open()` with the compression set as "auto". Although there might be a use of `bgz` I am not aware of?

 