### PR TITLE
Make FASTA index creation atomic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
     - 'pypy'
     - 'pypy3'
 install:
-    - pip install cython pysam requests coverage pyfasta pyvcf numpy
+    - pip install cython pysam requests coverage pyfasta pyvcf numpy nose-ignore-docstring
     - pip install biopython || true
     - python setup.py install
     - if [ ! -f samtools-1.2 ]; then curl -sL https://github.com/samtools/samtools/releases/download/1.2/samtools-1.2.tar.bz2 | tar -xjv; fi

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -9,6 +9,7 @@ import os
 import re
 import string
 import sys
+import shutil
 import warnings
 from collections import namedtuple
 from itertools import islice
@@ -29,7 +30,7 @@ if sys.version_info > (3, ):
 
 dna_bases = re.compile(r'([ACTGNactgnYRWSKMDVHBXyrwskmdvhbx]+)')
 
-__version__ = '0.5.9.5'
+__version__ = '0.6.0'
 
 
 class KeyFunctionError(ValueError):
@@ -515,7 +516,7 @@ class Faidx(object):
     def build_index(self):
         try:
             with self._fasta_opener(self.filename, 'rb') as fastafile:
-                with open(self.indexname, 'w') as indexfile:
+                with open(self.indexname + '.tmp', 'w') as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
                     rlen = 0  # reference character length
@@ -596,7 +597,9 @@ class Faidx(object):
                                 "Inconsistent line found in >{0} at "
                                 "line {1:n}.".format(rname,
                                                      bad_lines[0][0] + 1))
+            shutil.move(self.indexname + '.tmp', self.indexname)
         except (IOError, FastaIndexingError) as e:
+            os.remove(self.indexname + '.tmp')
             if isinstance(e, IOError):
                 raise IOError(
                     "%s may not be writable. Please use Fasta(rebuild=False), Faidx(rebuild=False) or faidx --no-rebuild."

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -438,8 +438,8 @@ class Faidx(object):
                     self.read_fai()
 
             except FastaIndexingError:
-                os.remove(self.indexname)
                 self.file.close()
+                os.remove(self.indexname + '.tmp')
                 raise
             except Exception:
                 # Handle potential exceptions other than 'FastaIndexingError'
@@ -599,7 +599,6 @@ class Faidx(object):
                                                      bad_lines[0][0] + 1))
             shutil.move(self.indexname + '.tmp', self.indexname)
         except (IOError, FastaIndexingError) as e:
-            os.remove(self.indexname + '.tmp')
             if isinstance(e, IOError):
                 raise IOError(
                     "%s may not be writable. Please use Fasta(rebuild=False), Faidx(rebuild=False) or faidx --no-rebuild."

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [nosetests]
 with-doctest=1
 verbosity=2
+with-ignore-docstrings=1


### PR DESCRIPTION
This addresses the comment in #174 and mitigates incomplete .fai file creation by first creating a temporary file, and then moving this file after successful creation.