### PR TITLE
Remove deprecated argument to random.shuffle

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -352,8 +352,8 @@ class Faidx(object):
             try:
                 from Bio import bgzf
                 from Bio import __version__ as bgzf_version
-                from distutils.version import LooseVersion
-                if LooseVersion(bgzf_version) < LooseVersion('1.73'):
+                from packaging.version import Version
+                if Version(bgzf_version) < Version('1.73'):
                     raise ImportError
             except ImportError:
                 raise ImportError(

--- a/tests/test_Fasta_synchronization.py
+++ b/tests/test_Fasta_synchronization.py
@@ -22,7 +22,7 @@ class _ThreadReadSequence(threading.Thread):
 
         seq_len = len(seq)
         sub_seq_slices = list(slice(i, min(i + 20, seq_len)) for i in range(0, seq_len, 20))
-        random.shuffle(sub_seq_slices, rand.random)
+        random.shuffle(sub_seq_slices)
 
         self.result_map = result_map
         self.result_lock = result_lock
@@ -52,7 +52,7 @@ class _ThreadWriteSequence(threading.Thread):
 
         seq_len = len(seq)
         sub_seq_slices = list(slice(i, min(i + 20, seq_len)) for i in range(0, seq_len, 20))
-        random.shuffle(sub_seq_slices, rand.random)
+        random.shuffle(sub_seq_slices)
 
         self.name = name
         self.seq = seq


### PR DESCRIPTION
https://github.com/mdshw5/pyfaidx/runs/4982115734?check_suite_focus=true#step:8:45

Using default random.shuffle method which is random.random.