### PR TITLE
Add fsspec support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ pyfasta
 pyvcf3
 numpy 
 biopython
+fsspec

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -557,7 +557,7 @@ class Faidx(object):
     def build_index(self):
         assert self.file.tell() == 0
         try:
-            with rewind(self.file) as fastafile:
+            with Rewind(self.file) as fastafile:
                 with TemporaryFile(mode='w+') as indexfile:
                     rname = None  # reference sequence name
                     offset = 0  # binary offset of end of current line
@@ -1248,7 +1248,7 @@ def wrap_sequence(n, sequence, fillvalue=''):
         yield ''.join(line + ("\n", ))
 
 
-class rewind:
+class Rewind:
     """
     use a fileobject in a context manager and rewind it back to its original position
     """

--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -444,9 +444,20 @@ class Faidx(object):
 
             if self._fs:
                 index_exists = self._fs.exists(self.indexname)
-                index_is_stale = index_exists and (
-                    self._fs.stat(self.filename)["mtime"] > self._fs.stat(self.indexname)["mtime"]
-                )
+                if index_exists:
+                    finfo = self._fs.stat(self.filename)
+                    iinfo = self._fs.stat(self.indexname)
+                    if 'mtime' in finfo:
+                        index_is_stale = finfo["mtime"] > iinfo["mtime"]
+                    elif "LastModified" in finfo:
+                        index_is_stale = finfo["LastModified"] > iinfo["LastModified"]
+                    elif "created" in finfo:
+                        index_is_stale = finfo["created"] > iinfo["created"]
+                    else:
+                        warnings.warn("for fsspec: %s assuming index is current" % type(self._fs).__name__)
+                        index_is_stale = False
+                else:
+                    index_is_stale = False
             else:
                 index_exists = os.path.exists(self.indexname)
                 index_is_stale = index_exists and (

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -1,0 +1,30 @@
+import os
+from zipfile import ZipFile
+
+import pytest
+
+from pyfaidx import Fasta
+
+try:
+    import fsspec
+    from fsspec.core import OpenFile
+except ImportError:
+    pytestmark = pytest.mark.skip
+
+
+@pytest.fixture(scope="session")
+def openfile_genes_fasta():
+    testdir = os.path.dirname(__file__)
+    genes_fasta = os.path.join(testdir, 'data', 'genes.fasta')
+
+    fs = fsspec.get_filesystem_class("memory")()
+    with fs.open("genes.fasta", mode="wb") as f:
+        with open(genes_fasta, mode="rb") as g:
+            f.write(g.read())
+
+    yield OpenFile(fs, 'genes.fasta', mode='rb')
+
+
+
+def test_fetch_whole_file(openfile_genes_fasta):
+    _ = Fasta(openfile_genes_fasta)

--- a/tests/test_fsspec.py
+++ b/tests/test_fsspec.py
@@ -1,5 +1,4 @@
 import os
-from zipfile import ZipFile
 
 import pytest
 


### PR DESCRIPTION
Hi @mdshw5,

I saw that there already was an attempt at implementing `fsspec` support and that the PR is basically stale.

So here's my attempt at implementing fsspec support:
This closes #165 and replaces #168

I explicitly tried to keep the required changes to a minimum, to simplify review.
This follows @manzt recommendations and accepts `fsspec.core.OpenFile` objects.
This can still be done cleaner by refactoring more of `Faidx.__init__`

Tests all pass and I added a single `fsspec` test. Let me know what the best tests would be for covering the base functionality of this library to test `fsspec` support.

Cheers,
Andreas :smiley:
