### PR TITLE
Minor change in pytest xfail usage in tests

### DIFF
--- a/tests/test_Fasta_bgzip.py
+++ b/tests/test_Fasta_bgzip.py
@@ -70,9 +70,9 @@ def test_line_len(remove_index):
     for record in fasta:
         assert len(next(iter(record))) == fasta.faidx.index[record.name].lenc
 
-@pytest.mark.xfail(raises=UnsupportedCompressionFormat)
 def test_mutable_bgzf(remove_index):
-    fasta = Fasta('data/genes.fasta.gz', mutable=True)
+    with pytest.raises(UnsupportedCompressionFormat):
+        fasta = Fasta('data/genes.fasta.gz', mutable=True)
 
 @pytest.mark.xfail(raises=NotImplementedError)
 def test_long_names(remove_index):
@@ -120,15 +120,14 @@ def test_fetch_end(remove_index):
                          480, 481)
     assert str(result) == expect
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_border(remove_index):
     """ Fetch past the end of a gene entry """
     faidx = Faidx('data/genes.fasta.gz')
     expect = 'TC'
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                         480, 500)
-    print(result)
-    assert str(result) == expect
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', 480, 500)
+        print(result)
+        assert str(result) == expect
 
 def test_rev(remove_index):
     faidx = Faidx('data/genes.fasta.gz')
@@ -137,33 +136,29 @@ def test_rev(remove_index):
                          480, 481)
     assert str(-result) == expect, result
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_past_bounds(remove_index):
     """ Fetch past the end of a gene entry """
     faidx = Faidx('data/genes.fasta.gz', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     480, 5000)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', 480, 5000)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_negative(remove_index):
     """ Fetch starting with a negative coordinate """
     faidx = Faidx('data/genes.fasta.gz', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     -10, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', -10, 10)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_reversed_coordinates(remove_index):
     """ Fetch starting with a negative coordinate """
     faidx = Faidx('data/genes.fasta.gz', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     50, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', 50, 10)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_keyerror(remove_index):
     """ Fetch a key that does not exist """
     faidx = Faidx('data/genes.fasta.gz', strict_bounds=True)
-    result = faidx.fetch('gi|joe|gb|KF435150.1|',
-                                     1, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|joe|gb|KF435150.1|', 1, 10)
 
 def test_blank_string(remove_index):
     """ seq[0:0] should return a blank string mdshw5/pyfaidx#53 """
@@ -230,12 +225,12 @@ def test_issue_79_fix_one_based_false_negate(remove_index):
     print(s.__dict__)
     assert (105, 100) == (s.start, s.end)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_border_padded(remove_index):
     """ Fetch past the end of a gene entry """
-    faidx = Faidx('data/genes.fasta.gz', default_seq='N')
-    expect = 'TCNNNNNNNNNNNNNNNNNNN'
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                         480, 500)
-    print(result)
-    assert str(result) == expect
+    with pytest.raises(FetchError):
+        faidx = Faidx('data/genes.fasta.gz', default_seq='N')
+        expect = 'TCNNNNNNNNNNNNNNNNNNN'
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|',
+                             480, 500)
+        print(result)
+        assert str(result) == expect

--- a/tests/test_faidx.py
+++ b/tests/test_faidx.py
@@ -16,9 +16,9 @@ def remove_index():
     except EnvironmentError:
         pass  # some tests may delete this file
 
-@pytest.mark.xfail(raises=BedError)
 def test_short_line_lengths(remove_index):
-    main(['data/genes.fasta', '--bed', 'data/malformed.bed'])
+    with pytest.raises(BedError):
+        main(['data/genes.fasta', '--bed', 'data/malformed.bed'])
 
 def test_fetch_whole_file(remove_index):
     main(['data/genes.fasta'])
@@ -28,9 +28,9 @@ def test_split_entry(remove_index):
     assert os.path.exists('gi557361099gbKF435150.1.fasta')
     os.remove('gi557361099gbKF435150.1.fasta')
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_error(remove_index):
-    main(['data/genes.fasta', 'gi|557361099|gb|KF435150.1|:1-1000'])
+    with pytest.raises(FetchError):
+        main(['data/genes.fasta', 'gi|557361099|gb|KF435150.1|:1-1000'])
     
 def test_key_warning(remove_index):
     main(['data/genes.fasta', 'foo'])

--- a/tests/test_feature_bounds_check.py
+++ b/tests/test_feature_bounds_check.py
@@ -93,33 +93,29 @@ def test_rev(remove_index):
                          480, 481)
     assert str(-result) == expect, result
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_past_bounds(remove_index):
     """ Fetch past the end of a gene entry """
     faidx = Faidx('data/genes.fasta', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     480, 5000)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', 480, 5000)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_negative(remove_index):
     """ Fetch starting with a negative coordinate """
     faidx = Faidx('data/genes.fasta', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     -10, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', -10, 10)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_reversed_coordinates(remove_index):
     """ Fetch starting with a negative coordinate """
     faidx = Faidx('data/genes.fasta', strict_bounds=True)
-    result = faidx.fetch('gi|557361099|gb|KF435150.1|',
-                                     50, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|557361099|gb|KF435150.1|', 50, 10)
 
-@pytest.mark.xfail(raises=FetchError)
 def test_fetch_keyerror(remove_index):
     """ Fetch a key that does not exist """
     faidx = Faidx('data/genes.fasta', strict_bounds=True)
-    result = faidx.fetch('gi|joe|gb|KF435150.1|',
-                                     1, 10)
+    with pytest.raises(FetchError):
+        result = faidx.fetch('gi|joe|gb|KF435150.1|', 1, 10)
 
 def test_blank_string(remove_index):
     """ seq[0:0] should return a blank string mdshw5/pyfaidx#53 """

--- a/tests/test_feature_indexing.py
+++ b/tests/test_feature_indexing.py
@@ -331,13 +331,12 @@ def test_read_back_index(remove_index):
     finally:
         locale.setlocale(locale.LC_NUMERIC, old_locale)
 
-@pytest.mark.xfail(raises=IndexNotFoundError)
 def test_issue_134_no_build_index(remove_index):
     """ Ensure that index file is not built when build_index=False. See mdshw5/pyfaidx#134.
     """
-    faidx = Faidx('data/genes.fasta', build_index=False)
+    with pytest.raises(IndexNotFoundError):
+        faidx = Faidx('data/genes.fasta', build_index=False)
 
-@pytest.mark.xfail(raises=FastaIndexingError)
 def test_issue_144_no_defline(remove_index):
     """ Ensure that an exception is raised when a file contains no deflines. See mdshw5/pyfaidx#144.
     """
@@ -347,6 +346,7 @@ def test_issue_144_no_defline(remove_index):
         # Write simple fasta file
         with open(fasta_path, 'w') as fasta_out:
             fasta_out.write("CTCCGGGCCCAT\nATAAAGCCTAAA\n")
-        faidx = Faidx(fasta_path)
+        with pytest.raises(FastaIndexingError):
+            faidx = Faidx(fasta_path)
     finally:
         shutil.rmtree(tmp_dir)

--- a/tests/test_feature_key_function.py
+++ b/tests/test_feature_key_function.py
@@ -60,9 +60,9 @@ def test_key_function_by_fetch(remove_index):
                          100, 150)
     assert str(result) == expect
 
-@pytest.mark.xfail(raises=ValueError)
 def test_duplicated_keys(remove_index):
-    genes = Fasta('data/genes.fasta', key_function=get_duplicated_gene_name)
+    with pytest.raises(ValueError):
+        genes = Fasta('data/genes.fasta', key_function=get_duplicated_gene_name)
 
 def test_duplicated_keys_shortest(remove_index):
     genes = Fasta('data/genes.fasta', key_function=get_duplicated_gene_name, duplicate_action="shortest")

--- a/tests/test_feature_read_ahead_buffer.py
+++ b/tests/test_feature_read_ahead_buffer.py
@@ -31,11 +31,11 @@ def test_buffer_exceed(remove_index):
     result = fasta['gi|557361099|gb|KF435150.1|'][0:400].seq.lower()
     assert result == expect
 
-@pytest.mark.xfail(raises=FetchError)
 def test_bounds_error(remove_index):
     fasta = Fasta('data/genes.fasta', read_ahead=300, strict_bounds=True)
-    result = fasta['gi|557361099|gb|KF435150.1|'][100-1:15000].seq.lower()
+    with pytest.raises(FetchError):
+        result = fasta['gi|557361099|gb|KF435150.1|'][100-1:15000].seq.lower()
 
-@pytest.mark.xfail(raises=ValueError)
 def test_buffer_value(remove_index):
-    Fasta('data/genes.fasta', read_ahead=0.5)
+    with pytest.raises(ValueError):
+        Fasta('data/genes.fasta', read_ahead=0.5)

--- a/tests/test_feature_sequence_as_raw.py
+++ b/tests/test_feature_sequence_as_raw.py
@@ -25,15 +25,15 @@ def test_as_raw_true(remove_index):
     result = fasta['gi|557361099|gb|KF435150.1|'][100-1:150].lower()
     assert result == expect
 
-@pytest.mark.xfail(raises=AttributeError)
 def test_as_raw_false_error(remove_index):
     fasta = Fasta('data/genes.fasta')
-    result = fasta['gi|557361099|gb|KF435150.1|'][100-1:150].lower()
+    with pytest.raises(AttributeError):
+        result = fasta['gi|557361099|gb|KF435150.1|'][100-1:150].lower()
 
-@pytest.mark.xfail(raises=AttributeError)
 def test_as_raw_true_error(remove_index):
     fasta = Fasta('data/genes.fasta', as_raw=True)
-    result = fasta['gi|557361099|gb|KF435150.1|'][100-1:150].seq.lower()
+    with pytest.raises(AttributeError):
+        result = fasta['gi|557361099|gb|KF435150.1|'][100-1:150].seq.lower()
 
 def test_as_raw_type_when_blen_lt_0(remove_index):
     fasta = Fasta('data/genes.fasta', as_raw=True)

--- a/tests/test_feature_split_char.py
+++ b/tests/test_feature_split_char.py
@@ -33,6 +33,6 @@ def test_key_function_by_fetch(remove_index):
                          100, 150)
     assert str(result) == expect
 
-@pytest.mark.xfail(raises=ValueError)
 def test_stop(remove_index):
-    fasta = Fasta('data/genes.fasta', split_char='|')
+    with pytest.raises(ValueError):
+        fasta = Fasta('data/genes.fasta', split_char='|')

--- a/tests/test_sequence_class.py
+++ b/tests/test_sequence_class.py
@@ -19,9 +19,9 @@ def test_negate_metadata():
     seq_neg = -seq
     assert seq_neg.__repr__() == seq.complement[::-1].__repr__()
 
-@pytest.mark.xfail(raises=ValueError)
 def test_seq_invalid():
-    seq_invalid.complement()
+    with pytest.raises(ValueError):
+        seq_invalid.complement()
 
 def test_integer_index():
     assert seq[1].seq == 'T'
@@ -29,15 +29,15 @@ def test_integer_index():
 def test_slice_index():
     assert seq[0:10].seq == 'TTGAAGATTT'
 
-@pytest.mark.xfail(raises=ValueError)
 def test_comp_invalid():
-    complement(comp_invalid)
+    with pytest.raises(ValueError):
+        complement(comp_invalid)
 
-@pytest.mark.xfail(raises=ValueError)
 def test_check_coordinates():
     x = Sequence(name='gi|557361099|gb|KF435150.1|', seq='TTGAAGATTTTGCATGCAGCAGGTGCGCAAGGTGAAATGTTCACTGTTAAA',
                  start=100, end=110)
-    x[:]
+    with pytest.raises(ValueError):
+        _ = x[:]
 
 def test_comp_valid():
     assert complement(comp_valid).startswith("AACTTCTAAAnCG")


### PR DESCRIPTION
Hi @mdshw5,

This PR is very much optional. I noticed that you were using `pytest.mark.xfail` to mark tests that raise specific Exceptions. This might be my OCD talking, but it's not the intended usage for xfail, which should be used to mark tests that either fail due to missing implementations or because they are expected to fail due to other reasons: https://docs.pytest.org/en/6.2.x/skipping.html

If the code should raise an Exception due to wrong input or other mistakes it's better to use `pytest.raises`.

In your test-suite it seemed to me that only two tests qualified for being marked as xfail.
Again, this is a very minor distinction. Feel free to close the PR if you prefer using xfail.

Cheers,
Andreas :smiley:
