### PR TITLE
fix ResourceWarning: unclosed file

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -857,6 +857,9 @@ class Faidx(object):
     def close(self):
         self.__exit__()
 
+    def __del__(self):
+        self.__exit__()
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
I'm seeing cases where a Fasta object is garbage collected without Fasta.faidx.file being closed, resulting in a `ResourceWarning: unclosed file <_io.FileIO name='genome.fa' mode='rb' closefd=True>`

This PR fixes the warning in the proper way.

I haven't managed to create a simple test case, but this works in my spaghetti code ;)