### PR TITLE
remove setuptools from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 dependencies = [
-    "setuptools",
     "importlib_metadata",
     "packaging"
 ]


### PR DESCRIPTION
pyfaidx does not rely on setuptools during day to day operation, so it can be safely removed from the runtime dependencies.

For the rationale, this change originates from the deprecation of the Debian package python3-pkg-resources along the upcoming Python 3.13 reported in [Debian bug #1083691].  For short, python3-pkg-resources happens to be pulled by the packaging tools when runtime dependency on setuptools is declared.

[Debian bug #1083691]: https://bugs.debian.org/1083691