### PR TITLE
do not needlessly require importlib_metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 dependencies = [
-    "importlib_metadata",
+    "importlib_metadata; python_version < '3.8'",
     "packaging"
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Hi,

This patch was included as a last-minute cleanup for Debian Trixie.

Greetings