### PR TITLE
fix: check for file before closing in __exit__

### DIFF
--- a/pyfaidx/__init__.py
+++ b/pyfaidx/__init__.py
@@ -886,7 +886,8 @@ class Faidx(object):
         return self
 
     def __exit__(self, *args):
-        self.file.close()
+        if hasattr(self, "file"):
+            self.file.close()
 
 
 class FastaRecord(object):


### PR DESCRIPTION
On error (e.g. opening non-existent files), the Faidx class __del__ is called, which in turn calls  __exit__, which unconditionally does self.file.close(). However if the file open or other such error caused the file not to be opened, you get an attribute error in addition to the original error. Therefore, the file.close() should be guarded behind hasattr().